### PR TITLE
removed .bowerrc from website processor template list

### DIFF
--- a/src/processors/website.js
+++ b/src/processors/website.js
@@ -25,8 +25,7 @@ module.exports = function generateWebsite(log, templateFinder) {
       'styles/docs.css',
       'styles/github.css',
       'styles/runnableExample.css',
-      'bower.json',
-      '.bowerrc'
+      'bower.json'
   ];
   var locals = {};
 
@@ -45,7 +44,7 @@ module.exports = function generateWebsite(log, templateFinder) {
         docs.push({
           docType: 'website',
           id: t,
-          template: 'app/' + (/^\./.test(t) ? 'dot' + t : t),
+          template: 'app/' + t,
           outputPath: t,
           locals: locals
         });

--- a/src/templates/app/dot.bowerrc
+++ b/src/templates/app/dot.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bower_components"
-}


### PR DESCRIPTION
So I'm locked into an old version of node at the moment and I've shimmed the various parts missing from pre-4 versions of node. The final obstacle was that the .bowerrc file was being copied out of the src/app/templates directory with the owner set to root which was causing permissions issues in the generateWebsite phase of the build.

I believe the underlying cause is related to this issue in some way:

https://github.com/npm/npm/issues/1862

and I can see that you've worked around it by handing the .bowerrc template entry to a dot.bowerrc template file. However, the file is simple setting the bower components directory to its default value so I'm assuming it can be removed, killing two birds with one stone?

Anyway, without this file I can generate my docs using node 0.10.25 and npm 1.3.24, which is currently necessary for the environment in which I'm working...
