### PR TITLE
Fix forEach() used on TypedArray, which is not supported on node < 4.0

### DIFF
--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -70,8 +70,10 @@ module.exports = function generateIndexProcessor(aliasMap, log, renderMarkdown) 
         })
 
         buffer.ensureCapacity(buffer.limit + filter.buckets.length*4);
+
         // append filter
-        filter.buckets.forEach(function(v) {
+        // use lodash for node <4.0 compat because buckets is a typed array
+        _.forEach(filter.buckets, function(v) {
           buffer.writeInt32(v);
         })
 


### PR DESCRIPTION
Not gonna push hard for node 0.12 support, but when the fix is this easy, why not? Official node 0.12 LTS is till the end of 2016.
