### PR TITLE
Override Custom Layout Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ api: {
   src: [
     '/src/**/*.js',
     '!**/test/**/*.js'
+  ],
+  // Any paths that contain your overriden templates relative to the grunt file
+  templatePaths: [
+    'dgeniAliveTemplates'
+  ],
+  // Any template files you want to override. Be sure to include the directory where these are located with the `templatePaths` option
+  templateOverrides: [
+    {
+      template: 'views/main.html',
+      file: 'main.html'
+    }
   ]
 }
 ```

--- a/src/processors/website.js
+++ b/src/processors/website.js
@@ -30,6 +30,19 @@ module.exports = function generateWebsite(log, templateFinder) {
   ];
   var locals = {};
 
+  /**
+   * An array of objects
+   * @type {Array}
+   *
+   * {
+   *    template: 'views/main.html',
+   *    file: 'main.html'
+   * }
+   *
+   * Be sure to add the template folder that your new main.html is in so it can find it.
+   */
+  var templateOverrides = [];
+
   return {
     locals: function(n, v) {
       if (void(v) === v) {
@@ -39,9 +52,46 @@ module.exports = function generateWebsite(log, templateFinder) {
       }
       return this;
     },
+    addTemplateOverride: function(template, file) {
+      if(template && file) {
+        templateOverrides.push({
+          template: template,
+          file: file
+        });
+      }
+    },
     $runBefore: ['rendering-docs'],
     $process: function (docs) {
+
+      var filteredTemplates = [];
+
+      // If you have an override, lets remove what it is overriding in the default templates
       templates.forEach(function(t) {
+        var shouldOverride = false;
+
+        templateOverrides.forEach(function(to) {
+          if(to.template === t) {
+            shouldOverride = true;
+          }
+        });
+
+        if(!shouldOverride) {
+          filteredTemplates.push(t);
+        }
+      });
+
+      // Add the overridden templates
+      templateOverrides.forEach(function(to) {
+        docs.push({
+          docType: 'website',
+          id: to.template,
+          template: to.file,
+          outputPath: to.template,
+          locals: locals
+        });
+      });
+
+      filteredTemplates.forEach(function(t) {
         docs.push({
           docType: 'website',
           id: t,

--- a/tasks/dgeni-alive.js
+++ b/tasks/dgeni-alive.js
@@ -34,8 +34,15 @@ module.exports = function (grunt) {
         var dest = path.resolve(this.data.dest);
 
         // enable debug
-        docgen.Package().config(function(log) {
+        docgen.Package().config(function(log, templateFinder) {
             log.level = debug? 'debug': 'info';
+
+            if(this.data.templatePaths) {
+                this.data.templatePaths.forEach(function(path) {
+                    // path/to/templates
+                    templateFinder.templateFolders.unshift(path);
+                });
+            }
         });
 
         var done = this.async();

--- a/tasks/dgeni-alive.js
+++ b/tasks/dgeni-alive.js
@@ -15,15 +15,15 @@ var path = require('path');
 var defaults = {
     root: process.cwd(),
     port: 10000,
-    host: "127.0.0.1",
+    host: '127.0.0.1',
     cache: 20,
     showDir : true,
     autoIndex: true,
-    ext: "html",
+    ext: 'html',
     runInBackground: false,
     cors: false,
     openBrowser : false
-}
+};
 
 module.exports = function (grunt) {
     // register task
@@ -33,14 +33,28 @@ module.exports = function (grunt) {
         var serve = this.options().serve;
         var dest = path.resolve(this.data.dest);
 
-        // enable debug
-        docgen.Package().config(function(log, templateFinder) {
-            log.level = debug? 'debug': 'info';
+        var apiOptions = this.data;
 
-            if(this.data.templatePaths) {
-                this.data.templatePaths.forEach(function(path) {
-                    // path/to/templates
-                    templateFinder.templateFolders.unshift(path);
+        // enable debug
+        docgen.Package().config(function(log) {
+            log.level = debug? 'debug': 'info';
+        })
+
+        .config(function(templateFinder) {
+            if(apiOptions.templatePaths) {
+                apiOptions.templatePaths.forEach(function(templatePath) {
+                    grunt.log.writeln('Adding template path: %s', path.resolve(templatePath));
+                    templateFinder.templateFolders.unshift(path.resolve(templatePath));
+                });
+            }
+        })
+
+        .config(function(generateWebsite) {
+            if(apiOptions.templateOverrides) {
+                apiOptions.templateOverrides.forEach(function(template) {
+                    grunt.log.writeln('Overriding template: %s', path.resolve(template.template));
+
+                    generateWebsite.addTemplateOverride(template.template, template.file);
                 });
             }
         });
@@ -59,10 +73,10 @@ module.exports = function (grunt) {
                 var options = _.extend({}, defaults, {
                         root: dest
                     }, serve);
-                var url = _.template("http://<%= host %>:<%= port %>/")(options);
+                var url = _.template('http://<%= host %>:<%= port %>/')(options);
                 var server = require('http-server').createServer(options);
                 server.listen(options.port, options.host, function () {
-                    grunt.log.writeln("Server running on %s", url);
+                    grunt.log.writeln('Server running on %s', url);
                     grunt.log.ok('Hit CTRL-C to stop the server');
                     if (options.openBrowser){
                         require('opener')(url, {


### PR DESCRIPTION
After having tried all sorts of hacks and ways to override the templates they all failed. I just decided to work an explicit template overriding system in. You can now define directories in grunt that you want to include for the template search and you can now define exact templates (found in processors/website.js) that you want to override. 

This makes it easier for people who don’t want to have to clone the repo to maintain their templates and who couldn’t figure out how to actually override the templates. 

I also am slightly OCD and updated some quote marks from double to single.
