### PR TITLE
Support for documenting React components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Parts of code were taken from generator-ngdoc.
 7. Added Errors Reference
 8. Added Search
 9. Added @sortOrder tag
-10. TBD
+10. Added JSX reader and @ngdoc type 'React' for documenting React components.
+11. TBD
 
 ## How it works
 1. Configure Dgeni package

--- a/src/docgen.js
+++ b/src/docgen.js
@@ -26,8 +26,16 @@ function configurePackage(p) {
     // append services
     p.factory(require('./services/transforms/errorTagTransform'))
 
+     // JSX file reader service
+     .factory(require('./file-readers/jsxFileReader'))
+
      // build navigation
      .processor(require('./processors/structuredParam'))
+
+     // add the JSX file reading service to the processor
+     .config(function (readFilesProcessor, jsxFileReader) {
+        readFilesProcessor.fileReaders.unshift(jsxFileReader);
+     })
 
      // generate website
      .config(function(generateWebsiteProcessor) {
@@ -83,6 +91,12 @@ function configurePackage(p) {
         });
 
         computeIdsProcessor.idTemplates.push({
+            docTypes: ['React'],
+            idTemplate: 'module:${module}.${docType}:${name}',
+            getAliases: getAliases
+        });
+
+        computeIdsProcessor.idTemplates.push({
             docTypes: ['error'],
             idTemplate: 'module:${module}.${docType}:${name}',
             getAliases: getAliases
@@ -111,6 +125,12 @@ function configurePackage(p) {
             pathTemplate: '${area}/${module}/${docType}/${name}',
             outputPathTemplate: 'partials/${area}/${module}/${docType}/${name}.html'
         });
+
+         computePathsProcessor.pathTemplates.push({
+             docTypes: ['React'],
+             pathTemplate: '${area}/${module}/${docType}/${name}',
+             outputPathTemplate: 'partials/${area}/${module}/${docType}/${name}.html'
+         });
 
         computePathsProcessor.pathTemplates.push({
             docTypes: ['error'],

--- a/src/file-readers/jsxFileReader.js
+++ b/src/file-readers/jsxFileReader.js
@@ -1,0 +1,17 @@
+/**
+ * Thanks to @maksimr
+ * https://gist.github.com/maksimr/5ed25c631d3ad6011263
+ */
+module.exports = function jsxFileReader(jsdocFileReader) {
+    return {
+        name: 'jsxFileReader',
+        defaultPattern: /\.jsx$/,
+        getDocs: function (fileInfo) {
+            // Workaround to get into 'api' area. Dgeni doesn't recognise
+            // other files than JS as part of the API.
+            // See `dgeni-packages/ngdoc/tag-defs/area.js`.
+            fileInfo.extension = 'js';
+            return jsdocFileReader.getDocs(fileInfo);
+        }
+    };
+};

--- a/src/templates/api/React.template.html
+++ b/src/templates/api/React.template.html
@@ -1,0 +1,76 @@
+{% include "lib/macros.html" -%}
+{% extends "api/api.template.html" %}
+
+{% block additional %}
+  <h2>Directive Info</h2>
+  <ul>
+    {% if doc.scope %}<li>This directive creates new scope.</li>{% endif %}
+    <li>This directive executes at priority level {$ doc.priority $}.</li>
+    {% if doc.multiElement %}<li>This directive can be used as {@link $compile#-multielement- multiElement}</li>{% endif %}
+  </ul>
+
+  {% block usage %}
+  <h2 id="usage">Usage</h2>
+  <div class="usage">
+  {% if doc.usage %}
+    {$ doc.usage | marked $}
+  {% else %}
+    <ul>
+    {% if doc.restrict.element %}
+      <li>as element:
+      {% if doc.name.indexOf('ng') == 0 -%}
+      (This directive can be used as custom element, but be aware of <a href="guide/ie">IE restrictions</a>).
+      {%- endif %}
+      {% code %}
+      <{$ doc.name | dashCase $}
+        {%- for param in doc.params -%}
+         {# skip attribute with name equal to directive name #}
+         {%- if (doc.name != param.alias and doc.name != param.name) %}
+          {$ directiveParam(param, '="', '"') $}
+         {%- endif -%}
+        {%- endfor %}>
+        ...
+      </{$ doc.name | dashCase $}>
+      {% endcode %}
+      </li>
+    {% endif -%}
+
+    {%- if doc.restrict.attribute -%}
+      <li>as attribute:
+        {% code %}
+        <{$ doc.element $}
+          {%- for param in doc.params %}
+          {$ directiveParam(param, '="', '"', false, doc.name) $}
+          {%- endfor %}>
+        ...
+        </{$ doc.element $}>
+        {% endcode %}
+      </li>
+    {% endif -%}
+
+    {%- if doc.restrict.cssClass -%}
+      <li>as CSS class:
+        {% code %}
+        {% set sep = joiner(' ') %}
+        <{$ doc.element $} class="
+        {%- for param in doc.params -%}
+          {$ sep() $}{$ directiveParam(param, ': ', ';', true) $}
+        {%- endfor %}"> ... </{$ doc.element $}>
+        {% endcode %}
+      </li>
+    {% endif -%}
+
+  {%- endif %}
+  </div>
+  {% endblock -%}
+
+  {%- if doc.animations %}
+  <h2 id="animations">Animations</h2>
+  {$ doc.animations | marked $}
+  {$ 'module:ngAnimate.$animate' | link('Click here', doc) $} to learn more about the steps involved in the animation.
+  {%- endif -%}
+
+  {% include "lib/params.template.html" %}
+  {% include "lib/events.template.html" %}
+  {% include "lib/throws.template.html" %}
+{% endblock %}


### PR DESCRIPTION
We are using `dgeni-alive` in our open-source project, [Superdesk](https://www.superdesk.org/), and it's been working great so far. So thank you for writing this great pre-configuration to `dgeni`!

We had some things that we needed to modify in order for it to suit our project better, so we've done that in our fork (on my account). I was thinking that these changes could benefit others too, who are in the same situation. By Google-ing around, I've noticed that some people are.

In this PR:

* Support for reading JSX files (no transforming).
* Support for new `@ngdoc` type called 'React' to allow documenting React components used in Angular projects

What do you think?