### PR TITLE
Fix/Improve Live Examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You could also specify stylesheets in the stylesheets array.
 ### Configuring iFrame-Resizer
 iFrame-Resizer (https://github.com/davidjbradshaw/iframe-resizer) is used to resize example iframes when "examples-ext" is used.
 The following options for iframe resizer may be specified as example attributes (see iframe-resizer readme for explainations of what they do):
-minHeight, maxHeight, heightCalculationMethod, scrolling, tolerance.
+log, minHeight, maxHeight, heightCalculationMethod, scrolling, tolerance.
 Options are set as attributes in your example tag in the documentation as snake-case with frame- prefixed before the option name.
 This is an example of setting minHeight to 200:
  ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ deployments: [{
 		commonFiles: {
 			scripts: [
 				'https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js',
-				'/docs/resources/js/examples.js'
+				'docs/resources/js/examples.js'
 			],
 			stylesheets: []
 		}
@@ -145,8 +145,19 @@ deploymentTarget: 'default'
 ```
 This example configuration defines a deployment "default" and makes it the default target.
 It tells every example to include jquery and a js file relative to the build path called "examples.js".
-Local files will be copied automatically in the same place as the generated example html if you use "examples-ext" package.
+Paths that do not begin with http(s), // or / will be copied automatically in the same place as the generated example html if you use "examples-ext" package.
 You could also specify stylesheets in the stylesheets array.
+
+### Configuring iFrame-Resizer
+iFrame-Resizer (https://github.com/davidjbradshaw/iframe-resizer) is used to resize example iframes when "examples-ext" is used.
+The following options for iframe resizer may be specified as example attributes (see iframe-resizer readme for explainations of what they do):
+minHeight, maxHeight, heightCalculationMethod, scrolling, tolerance.
+Options are set as attributes in your example tag in the documentation as snake-case with frame- prefixed before the option name.
+This is an example of setting minHeight to 200:
+ ```
+ * <example module="myModule" name="myExample" frame-min-height="200">
+```
+If you wish to disable iframe-resizer for an example add `frame-no-resize="true"` to your example.
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -115,5 +115,38 @@ api: {
 }
 ```
 
+## Setting up Live Examples
+Add the dgeni-packages examples package to your package array.
+If you want the "Edit in Plunker" button and file tabs also add dgeni-alive examples-ext.
+Your package array should look something like this:
+```
+packages: [
+	'dgeni-packages/ngdoc',
+	'dgeni-packages/examples',
+	'./packages/examples-ext',
+],
+```
+You will also need to add deployments configuration to generate the examples.
+This is added to the "options" section of the configuration.
+```
+deployments: [{
+	name: 'default',
+	examples: {
+		commonFiles: {
+			scripts: [
+				'https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js',
+				'/docs/resources/js/examples.js'
+			],
+			stylesheets: []
+		}
+	}
+}],
+deploymentTarget: 'default'
+```
+This example configuration defines a deployment "default" and makes it the default target.
+It tells every example to include jquery and a js file relative to the build path called "examples.js".
+Local files will be copied automatically in the same place as the generated example html if you use "examples-ext" package.
+You could also specify stylesheets in the stylesheets array.
+
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -154,10 +154,20 @@ The following options for iframe resizer may be specified as example attributes 
 log, minHeight, maxHeight, heightCalculationMethod, scrolling, tolerance.
 Options are set as attributes in your example tag in the documentation as snake-case with frame- prefixed before the option name.
 This is an example of setting minHeight to 200:
- ```
+```
  * <example module="myModule" name="myExample" frame-min-height="200">
 ```
 If you wish to disable iframe-resizer for an example add `frame-no-resize="true"` to your example.
+
+## Additional Packages
+dgeni-alive provides several packages to supplement the default dgeni-packages.
+To include a package from dgeni-alive in grunt configuration you would add `./packages/{package-name}` to you packages array.
+* examples-ext: provides improvements to the live examples
+* jsdoc-ext: provides additional jsdoc tags and code expressions (included by default)
+* jsx: provides jsx support
+* links-ext: provides extensions to dgeni-packages/links (included by default)
+* ngdoc-ext: provides extensions to dgeni-packages/ngdoc (included by default)
+* website: website package (included by default)
 
 ## License
 MIT

--- a/src/docgen.js
+++ b/src/docgen.js
@@ -29,12 +29,6 @@ function configurePackage(p) {
      // build navigation
      .processor(require('./processors/structuredParam'))
 
-     /* commenting out the following because it's not a default package
-     // add the JSX file reading service to the processor
-     .config(function (readFilesProcessor, jsxFileReader) {
-        readFilesProcessor.fileReaders.unshift(jsxFileReader);
-     })*/
-
      // generate website
      .config(function(generateWebsiteProcessor) {
         generateWebsiteProcessor

--- a/src/docgen.js
+++ b/src/docgen.js
@@ -29,10 +29,11 @@ function configurePackage(p) {
      // build navigation
      .processor(require('./processors/structuredParam'))
 
+     /* commenting out the following because it's not a default package
      // add the JSX file reading service to the processor
      .config(function (readFilesProcessor, jsxFileReader) {
         readFilesProcessor.fileReaders.unshift(jsxFileReader);
-     })
+     })*/
 
      // generate website
      .config(function(generateWebsiteProcessor) {

--- a/src/packages/examples-ext/index.js
+++ b/src/packages/examples-ext/index.js
@@ -7,11 +7,18 @@ var path = require('path');
  */
 module.exports = new Package('examples-ext', [require('dgeni-packages/examples')])
 
-// Add in the real processors for this package
-.processor(require('./processors/exampleDependenciesBuilder'))
+  // Add in the real processors for this package
+  .processor(require('./processors/exampleDependenciesBuilder'))
 
-// add more templates location
-.config(function(templateFinder) {
-  templateFinder.templateFolders.unshift(path.resolve(__dirname, 'templates'));
-})
-;
+  // add more templates location
+  .config(function(templateFinder) {
+      templateFinder.templateFolders.unshift(path.resolve(__dirname, 'templates'));
+  })
+
+  // add doctype for example-dependency
+  .config(function(computePathsProcessor, computeIdsProcessor) {
+      computeIdsProcessor.idTemplates.push({
+          docTypes: ['example-dependency'],
+          getAliases: function(doc) { return [doc.id]; }
+      });
+  });

--- a/src/packages/examples-ext/processors/exampleDependenciesBuilder.js
+++ b/src/packages/examples-ext/processors/exampleDependenciesBuilder.js
@@ -15,9 +15,12 @@ var fs = require('fs');
 module.exports = function exampleDependenciesBuilder (readFilesProcessor, log, generateExamplesProcessor, exampleMap) {
   /**
    * Regular expression to check if path is external
+   * Matches strings that start with http(s)://, // or /
+   * Strings that match will not be copied to the docs directory
+   * They assume some external thing has managed that
    * @type {RegExp}
    */
-  var REMOTE_REG = /(https?:)?\/\//i;
+  var REMOTE_REG = /^(https?:)?\/?\//i;
 
   /**
    * Document type for docs entries
@@ -44,7 +47,14 @@ module.exports = function exampleDependenciesBuilder (readFilesProcessor, log, g
           processor = processDependency.bind(null, docs, name);
 
           commonFiles = deployment.examples && deployment.examples.commonFiles || {};
-          (commonFiles.scripts || []).forEach(processor);
+
+          if (!commonFiles.hasOwnProperty('scripts')) {
+            commonFiles.scripts = [];
+          }
+          // add iframe resizer script
+          commonFiles.scripts.push('/bower_components/iframe-resizer/js/iframeResizer.contentWindow.min.js');
+
+          commonFiles.scripts.forEach(processor);
           (commonFiles.stylesheets || []).forEach(processor);
 		}
       }

--- a/src/packages/examples-ext/processors/exampleDependenciesBuilder.js
+++ b/src/packages/examples-ext/processors/exampleDependenciesBuilder.js
@@ -36,15 +36,18 @@ module.exports = function exampleDependenciesBuilder (readFilesProcessor, log, g
 
       // traverse deployments, check project dependencies and add local file
       // dependencies to the list of generated documents
-      generateExamplesProcessor.deployments.forEach(function(deployment) {
+      var deployment, name, processor, commonFiles;
+      for (var x in generateExamplesProcessor.deployments) {
+        if (generateExamplesProcessor.deployments.hasOwnProperty(x)) {
+          deployment = generateExamplesProcessor.deployments[x];
+          name = makeUniqueName(deployments, deployment.name);
+          processor = processDependency.bind(null, docs, name);
 
-        var name = makeUniqueName(deployments, deployment.name);
-        var processor = processDependency.bind(null, docs, name);
-
-        var commonFiles = deployment.examples && deployment.examples.commonFiles || {};
-        (commonFiles.scripts || []).forEach(processor);
-        (commonFiles.stylesheets || []).forEach(processor);
-      })
+          commonFiles = deployment.examples && deployment.examples.commonFiles || {};
+          (commonFiles.scripts || []).forEach(processor);
+          (commonFiles.stylesheets || []).forEach(processor);
+		}
+      }
     }
   };
 

--- a/src/packages/examples-ext/processors/exampleDependenciesBuilder.js
+++ b/src/packages/examples-ext/processors/exampleDependenciesBuilder.js
@@ -56,7 +56,14 @@ module.exports = function exampleDependenciesBuilder (readFilesProcessor, log, g
 
           commonFiles.scripts.forEach(processor);
           (commonFiles.stylesheets || []).forEach(processor);
-		}
+
+          // ensure final commonFiles is set even if none was previously defined
+          if (!deployment.hasOwnProperty('examples')) {
+            deployment.examples = { commonFiles: commonFiles };
+          } else {
+            deployment.examples.commonFiles = commonFiles;
+          }
+        }
       }
     }
   };

--- a/src/packages/examples-ext/templates/runnableExample.template.html
+++ b/src/packages/examples-ext/templates/runnableExample.template.html
@@ -4,6 +4,7 @@
 <plnkr-opener example-path="{$ doc.path $}"></plnkr-opener>
 <div class="runnable-example"
     path="{$ doc.example.deployments[deploymentTarget].path $}"
+    frame-id="{$ doc.example.id $}"
     {%- for attrName, attrValue in doc.example.attributes %}
     {$ attrName $}="{$ attrValue $}"{% endfor %}>
 
@@ -22,7 +23,7 @@
 	{% endfor %}
     </md-tabs>
   </md-content>
-  <iframe class="runnable-example-frame" src="{$ doc.example.deployments[deploymentTarget].outputPath $}" name="{$ doc.example.id $}"></iframe>
+  <iframe class="runnable-example-frame" src="{$ doc.example.deployments[deploymentTarget].outputPath $}" name="{$ doc.example.id $}" id="{$ doc.example.id $}"></iframe>
 </div>
 
 

--- a/src/packages/examples-ext/templates/runnableExample.template.html
+++ b/src/packages/examples-ext/templates/runnableExample.template.html
@@ -10,17 +10,17 @@
 
   <md-content>
     <md-tabs md-dynamic-height="false" md-border-bottom>
-	{% for fileName, file in doc.example.files %}
-	  <md-tab label="{$ file.name $}">
-		<md-content class="md-padding">
-		  <div class="runnable-example-file" {% for attrName, attrValue in file.attributes %}{$ attrName $}="{$ attrValue $}"{% endfor %}>
-		  {% code -%}
-			{$ file.fileContents $}
-		  {%- endcode %}
-		  </div>
-		</md-content>
-	  </md-tab>
-	{% endfor %}
+    {% for fileName, file in doc.example.files %}
+      <md-tab label="{$ file.name $}">
+        <md-content class="md-padding">
+          <div class="runnable-example-file" {% for attrName, attrValue in file.attributes %}{$ attrName $}="{$ attrValue $}"{% endfor %}>
+          {% code -%}
+            {$ file.fileContents $}
+          {%- endcode %}
+          </div>
+        </md-content>
+      </md-tab>
+    {% endfor %}
     </md-tabs>
   </md-content>
   <iframe class="runnable-example-frame" src="{$ doc.example.deployments[deploymentTarget].outputPath $}" name="{$ doc.example.id $}" id="{$ doc.example.id $}"></iframe>

--- a/src/packages/examples-ext/templates/runnableExample.template.html
+++ b/src/packages/examples-ext/templates/runnableExample.template.html
@@ -1,30 +1,30 @@
-{# Be aware that we need these extra new lines here or marked will not realise that the <div>
+{# Be aware that we need these extra new lines here or marked will not realize that the <div>
    is HTML and wrap each line in a <p> - thus breaking the HTML #}
 
-
+<plnkr-opener example-path="{$ doc.path $}"></plnkr-opener>
 <div class="runnable-example"
-    path="{$ doc.example.deployments.default.path $}"
+    path="{$ doc.example.deployments[deploymentTarget].path $}"
     {%- for attrName, attrValue in doc.example.attributes %}
     {$ attrName $}="{$ attrValue $}"{% endfor %}>
 
   <md-content>
     <md-tabs md-dynamic-height="false" md-border-bottom>
-    {% for fileName, file in doc.example.files %}
-      <md-tab label="{$ file.name $}">
-        <md-content class="md-padding">
-          <div class="runnable-example-file" {% for attrName, attrValue in file.attributes %}{$ attrName $}="{$ attrValue $}"{% endfor %}>
-          {% code -%}
-            {$ file.fileContents $}
-          {%- endcode %}
-          </div>
-        </md-content>
-      </md-tab>
-    {% endfor %}
+	{% for fileName, file in doc.example.files %}
+	  <md-tab label="{$ file.name $}">
+		<md-content class="md-padding">
+		  <div class="runnable-example-file" {% for attrName, attrValue in file.attributes %}{$ attrName $}="{$ attrValue $}"{% endfor %}>
+		  {% code -%}
+			{$ file.fileContents $}
+		  {%- endcode %}
+		  </div>
+		</md-content>
+	  </md-tab>
+	{% endfor %}
     </md-tabs>
   </md-content>
   <iframe class="runnable-example-frame" src="{$ doc.example.deployments[deploymentTarget].outputPath $}" name="{$ doc.example.id $}"></iframe>
 </div>
 
 
-{# Be aware that we need these extra new lines here or marked will not realise that the <div>
+{# Be aware that we need these extra new lines here or marked will not realize that the <div>
    above is HTML and wrap each line in a <p> - thus breaking the HTML #}

--- a/src/packages/jsdoc-ext/index.js
+++ b/src/packages/jsdoc-ext/index.js
@@ -11,4 +11,8 @@ module.exports = new Package('jsdoc-ext', [require('dgeni-packages/jsdoc')])
 // Add more tag definitions
 .config(function(parseTagsProcessor, getInjectables) {
   parseTagsProcessor.tagDefinitions = parseTagsProcessor.tagDefinitions.concat(getInjectables(require('./tag-defs')));
+})
+// Add more code name matchers
+.config(function(codeNameService, getInjectables) {
+  codeNameService.matchers = getInjectables(require('./services/code-name-matchers'));
 });

--- a/src/packages/jsdoc-ext/services/code-name-matchers/index.js
+++ b/src/packages/jsdoc-ext/services/code-name-matchers/index.js
@@ -1,2 +1,3 @@
 module.exports = [
+	require('./this-expression.js')
 ];

--- a/src/packages/jsdoc-ext/services/code-name-matchers/this-expression.js
+++ b/src/packages/jsdoc-ext/services/code-name-matchers/this-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ThisExpressionNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function ThisExpressionNodeMatcherFactory (codeNameService) {
+	/**
+	 * @param {Node} node AST node to process
+	 * @returns {String|Null} code name from node
+	 */
+	return function ThisExpressionNodeMatcher (node) {
+		return null;
+	}
+};

--- a/src/packages/navigation/index.js
+++ b/src/packages/navigation/index.js
@@ -5,7 +5,7 @@ var path = require('path');
  * @dgPackage navigation
  * @description Navigation builder package
  */
-module.exports = new Package('navigation', [])
+module.exports = new Package('navigation', [require('../jsdoc-ext')])
 
   // Add in the real processors for this package
   .processor(require('./processors/navigation'))

--- a/src/packages/navigation/processors/nav-area-mapper/docs.js
+++ b/src/packages/navigation/processors/nav-area-mapper/docs.js
@@ -40,7 +40,7 @@ module.exports = function navigationMapper_DOCS(aliasMap, log) {
   Object.defineProperty(docsMapper, 'sortBy', {
     value: [
       'sortOrder',
-      'name'
+      'title'
     ]});
 
   return docsMapper;

--- a/src/packages/navigation/processors/nav-area-mapper/docs.js
+++ b/src/packages/navigation/processors/nav-area-mapper/docs.js
@@ -30,11 +30,11 @@ module.exports = function navigationMapper_DOCS(aliasMap, log) {
 
 
   Object.defineProperty(docsMapper, 'area', {
-    value: 'guide'
+    value: 'docs'
   });
 
   Object.defineProperty(docsMapper, 'title', {
-    value: 'Guide'
+    value: 'Docs'
   });
 
   Object.defineProperty(docsMapper, 'sortBy', {

--- a/src/packages/navigation/processors/nav-area-mapper/guide.js
+++ b/src/packages/navigation/processors/nav-area-mapper/guide.js
@@ -40,7 +40,7 @@ module.exports = function navigationMapper_GUIDE(aliasMap, log) {
   Object.defineProperty(guideMapper, 'sortBy', {
     value: [
       'sortOrder',
-      'name'
+      'title'
     ]});
 
   return guideMapper;

--- a/src/packages/search/index.js
+++ b/src/packages/search/index.js
@@ -5,7 +5,7 @@ var path = require('path');
  * @dgPackage search
  * @description Package maintaining search index processing
  */
-module.exports = new Package('search', [])
+module.exports = new Package('search', [require('../jsdoc-ext')])
 
 // Add in the real processors for this package
 .processor(require('./processors/search-index'))

--- a/src/packages/website/processors/website.js
+++ b/src/packages/website/processors/website.js
@@ -17,6 +17,7 @@ module.exports = function generateWebsiteProcessor (log) {
       'views/navbar.html',
       'views/sidebar.html',
       'views/searchbox.html',
+	  'scripts/examples.js',
       'scripts/a.directive.js',
       'scripts/docs.controller.js',
       'scripts/index.js',

--- a/src/packages/website/templates/website/bower.json
+++ b/src/packages/website/templates/website/bower.json
@@ -8,6 +8,8 @@
     "bootstrap": "3.3.x",
     "google-code-prettify": "1.0.1",
     "angular-animate": "1.5.x",
+    "angular-aria": "1.5.x",
+    "angular-messages": "1.5.x",
     "angular-material": "1.0.x",
     "bytebuffer": "5.0.x",
     "font-awesome": "fontawesome#~4.5.0"

--- a/src/packages/website/templates/website/bower.json
+++ b/src/packages/website/templates/website/bower.json
@@ -7,6 +7,7 @@
     "jquery": "2.x.x",
     "bootstrap": "3.3.x",
     "google-code-prettify": "1.0.1",
+    "angular-animate": "1.5.x",
     "angular-material": "1.0.x",
     "bytebuffer": "5.0.x",
     "font-awesome": "fontawesome#~4.5.0"

--- a/src/packages/website/templates/website/bower.json
+++ b/src/packages/website/templates/website/bower.json
@@ -12,7 +12,8 @@
     "angular-messages": "1.5.x",
     "angular-material": "1.0.x",
     "bytebuffer": "5.0.x",
-    "font-awesome": "fontawesome#~4.5.0"
+    "font-awesome": "fontawesome#~4.5.0",
+    "iframe-resizer": "3.5.x"
   },
   "overrides": {
     "bootstrap": {
@@ -23,6 +24,11 @@
     "font-awesome": {
       "main": [
         "css/font-awesome.css"
+      ]
+    },
+    "iframe-resizer": {
+      "main": [
+        "js/iframeResizer.min.js"
       ]
     }
   },

--- a/src/packages/website/templates/website/index.html
+++ b/src/packages/website/templates/website/index.html
@@ -32,6 +32,7 @@
     <!-- build:js({app,.tmp}) scripts/app.js -->
       <!-- inject:env_ignore -->
       <!-- endinject -->
+      <script src="scripts/examples.js"></script>
       <script src="scripts/index.js"></script>
       <script src="scripts/pre.directive.js"></script>
       <script src="scripts/a.directive.js"></script>

--- a/src/packages/website/templates/website/scripts/examples.js
+++ b/src/packages/website/templates/website/scripts/examples.js
@@ -18,12 +18,36 @@ angular.module('examples', [])
 		return {
 			restrict: 'C',
 			scope : true,
-			controller : ['$scope', function($scope) {
+			controller : ['$scope', '$attrs', function($scope, $attrs) {
 				$scope.setTab = function(index) {
 					var tab = $scope.tabs[index];
 					$scope.activeTabIndex = index;
 					$scope.$broadcast('tabChange', index, tab);
 				};
+
+				if (angular.isFunction(iFrameResize) && $attrs.frameId) {
+					if ($attrs.hasOwnProperty('frameNoResize') && $attrs.frameNoResize == "true") {
+						// noop
+					} else {
+						var iframeOpts = {};
+						if ($attrs.hasOwnProperty('frameMinHeight')) {
+							iframeOpts.minHeight = $attrs.frameMinHeight;
+						}
+						if ($attrs.hasOwnProperty('frameMaxHeight')) {
+							iframeOpts.maxHeight = $attrs.frameMaxHeight;
+						}
+						if ($attrs.hasOwnProperty('frameHeightCalculationMethod')) {
+							iframeOpts.heightCalculationMethod = $attrs.frameHeightCalculationMethod;
+						}
+						if ($attrs.hasOwnProperty('frameScrolling')) {
+							iframeOpts.scrolling = $attrs.frameScrolling;
+						}
+						if ($attrs.hasOwnProperty('frameTolerance')) {
+							iframeOpts.tolerance = $attrs.frameTolerance;
+						}
+						iFrameResize(iframeOpts, '#' + $attrs.frameId);
+					}
+				}
 			}],
 			compile : function(element) {
 				element.html(tpl + element.html());
@@ -186,6 +210,7 @@ angular.module('examples', [])
 							.then(function(response) {
 								return {
 									name: filename,
+									// get content and replace relative links with full path
 									content: response.data.replace(/(src\s*=\s*['"])([\.\/])/ig,
 										'$1' + location.protocol + '//' + location.host + '/' + exampleFolder + '/$2')
 								};

--- a/src/packages/website/templates/website/scripts/examples.js
+++ b/src/packages/website/templates/website/scripts/examples.js
@@ -49,7 +49,18 @@ angular.module('examples', [])
 						if ($attrs.hasOwnProperty('frameLog') && $attrs.frameLog === 'true') {
 							iframeOpts.log = true;
 						}
-						iFrameResize(iframeOpts, '#' + $attrs.frameId);
+						// attach iframe resizer
+						var iframe = iFrameResize(iframeOpts, '#' + $attrs.frameId);
+						// add event to teardown iframe when destroyed
+						$scope.$on('$destroy', function() {
+							if (angular.isArray(iframe)) {
+								for (var i=0,l=iframe.length; i<l; i++) {
+									if (iframe[i] && iframe[i].hasOwnProperty('iFrameResizer')) {
+										iframe[i].iFrameResizer.close();
+									}
+								}
+							}
+						});
 					}
 				}
 			}],

--- a/src/packages/website/templates/website/scripts/examples.js
+++ b/src/packages/website/templates/website/scripts/examples.js
@@ -182,11 +182,8 @@ angular.module('examples', [])
 							filename = 'index.html';
 						}
 
-						console.info('getting data for ', filename);
 						filePromises.push($http.get(exampleFolder + '/' + filename, { transformResponse: [] })
 							.then(function(response) {
-								console.info('got data for ', filename);
-
 								return {
 									name: filename,
 									content: response.data.replace(/(src\s*=\s*['"])([\.\/])/ig,

--- a/src/packages/website/templates/website/scripts/examples.js
+++ b/src/packages/website/templates/website/scripts/examples.js
@@ -25,6 +25,7 @@ angular.module('examples', [])
 					$scope.$broadcast('tabChange', index, tab);
 				};
 
+				// see https://github.com/davidjbradshaw/iframe-resizer for explanation of options
 				if (angular.isFunction(iFrameResize) && $attrs.frameId) {
 					if ($attrs.hasOwnProperty('frameNoResize') && $attrs.frameNoResize == "true") {
 						// noop
@@ -44,6 +45,9 @@ angular.module('examples', [])
 						}
 						if ($attrs.hasOwnProperty('frameTolerance')) {
 							iframeOpts.tolerance = $attrs.frameTolerance;
+						}
+						if ($attrs.hasOwnProperty('frameLog') && $attrs.frameLog === 'true') {
+							iframeOpts.log = true;
 						}
 						iFrameResize(iframeOpts, '#' + $attrs.frameId);
 					}

--- a/src/packages/website/templates/website/scripts/examples.js
+++ b/src/packages/website/templates/website/scripts/examples.js
@@ -1,0 +1,204 @@
+'use strict';
+
+angular.module('examples', [])
+
+	.directive('runnableExample', [function() {
+		var exampleClassNameSelector = '.runnable-example-file';
+		var tpl =
+			'<nav class="runnable-example-tabs" ng-if="tabs">' +
+			'  <a ng-class="{active:$index==activeTabIndex}"' +
+			'ng-repeat="tab in tabs track by $index" ' +
+			'href="" ' +
+			'class="btn"' +
+			'ng-click="setTab($index)">' +
+			'    {{ tab }}' +
+			'  </a>' +
+			'</nav>';
+
+		return {
+			restrict: 'C',
+			scope : true,
+			controller : ['$scope', function($scope) {
+				$scope.setTab = function(index) {
+					var tab = $scope.tabs[index];
+					$scope.activeTabIndex = index;
+					$scope.$broadcast('tabChange', index, tab);
+				};
+			}],
+			compile : function(element) {
+				element.html(tpl + element.html());
+				return function(scope, element) {
+					var node = element[0];
+					var examples = node.querySelectorAll(exampleClassNameSelector);
+					var tabs = [];
+					angular.forEach(examples, function(child, index) {
+						tabs.push(child.getAttribute('name'));
+					});
+
+					if (tabs.length > 0) {
+						scope.tabs = tabs;
+						scope.$on('tabChange', function(e, index, title) {
+							angular.forEach(examples, function(child) {
+								child.style.display = 'none';
+							});
+							var selected = examples[index];
+							selected.style.display = 'block';
+						});
+						scope.setTab(0);
+					}
+				};
+			}
+		};
+	}])
+
+	.factory('formPostData', ['$document', function($document) {
+		return function(url, newWindow, fields) {
+			/**
+			 * If the form posts to target="_blank", pop-up blockers can cause it not to work.
+			 * If a user choses to bypass pop-up blocker one time and click the link, they will arrive at
+			 * a new default plnkr, not a plnkr with the desired template.  Given this undesired behavior,
+			 * some may still want to open the plnk in a new window by opting-in via ctrl+click.  The
+			 * newWindow param allows for this possibility.
+			 */
+			var target = newWindow ? '_blank' : '_self';
+			var form = angular.element('<form style="display: none;" method="post" action="' + url + '" target="' + target + '"></form>');
+			angular.forEach(fields, function(value, name) {
+				var input = angular.element('<input type="hidden" name="' +  name + '">');
+				input.attr('value', value);
+				form.append(input);
+			});
+			$document.find('body').append(form);
+			form[0].submit();
+			form.remove();
+		};
+	}])
+
+	.factory('createCopyrightNotice', function() {
+		var COPYRIGHT = 'Copyright ' + (new Date()).getFullYear() + ' All Rights Reserved.\n';
+		var COPYRIGHT_JS_CSS = '\n\n/*\n' + COPYRIGHT + '\n*/';
+		var COPYRIGHT_HTML = '\n\n<!-- \n' + COPYRIGHT + '\n-->';
+
+		return function getCopyright(filename) {
+			switch (filename.substr(filename.lastIndexOf('.'))) {
+				case '.html':
+					return COPYRIGHT_HTML;
+				case '.js':
+				case '.css':
+					return COPYRIGHT_JS_CSS;
+				case '.md':
+					return COPYRIGHT;
+			}
+			return '';
+		};
+	})
+
+	.directive('plnkrOpener', ['$q', 'getExampleData', 'formPostData', 'createCopyrightNotice', function($q, getExampleData, formPostData, createCopyrightNotice) {
+		return {
+			scope: {},
+			bindToController: {
+				'examplePath': '@'
+			},
+			controllerAs: 'plnkr',
+			template: '<button ng-click="plnkr.open($event)" class="btn pull-right"> <i class="glyphicon glyphicon-edit">&nbsp;</i> Edit in Plunker</button> ',
+			controller: [function PlnkrOpenerCtrl() {
+				var ctrl = this;
+
+				ctrl.example = {
+					path: ctrl.examplePath,
+					manifest: undefined,
+					files: undefined,
+					name: 'Dgeni Example'
+				};
+
+				ctrl.prepareExampleData = function() {
+					if (ctrl.example.manifest) {
+						return $q.resolve(ctrl.example);
+					}
+
+					return getExampleData(ctrl.examplePath).then(function(data) {
+						ctrl.example.files = data.files;
+						ctrl.example.manifest = data.manifest;
+
+						// Build a pretty title for the Plunkr
+						var exampleNameParts = data.manifest.name.split('-');
+						angular.forEach(exampleNameParts, function(part, index) {
+							exampleNameParts[index] = part.charAt(0).toUpperCase() + part.substr(1);
+						});
+						ctrl.example.name = exampleNameParts.join(' - ');
+
+						return ctrl.example;
+					});
+				};
+
+				ctrl.open = function(clickEvent) {
+
+					var newWindow = clickEvent.ctrlKey || clickEvent.metaKey;
+
+					var postData = {
+						'tags[0]': 'dgeni',
+						'tags[1]': 'example',
+						'private': true
+					};
+
+					// Make sure the example data is available.
+					// If an XHR must be made, this might break some pop-up blockers when
+					// new window is requested
+					ctrl.prepareExampleData()
+						.then(function() {
+							angular.forEach(ctrl.example.files, function(file) {
+								postData['files[' + file.name + ']'] = file.content + createCopyrightNotice(file.name);
+							});
+
+							postData.description = ctrl.example.name;
+
+							formPostData(location.protocol + '//plnkr.co/edit/?p=preview', newWindow, postData);
+						});
+
+				};
+
+				ctrl.$onInit = function() {
+					// Initialize the example data, so it's ready when clicking the open button.
+					// Otherwise pop-up blockers will prevent a new window from opening
+					ctrl.prepareExampleData(ctrl.example.path);
+				};
+			}]
+		};
+	}])
+
+	.factory('getExampleData', ['$http', '$q', function($http, $q) {
+		return function(exampleFolder) {
+			// Load the manifest for the example
+			return $http.get(exampleFolder + '/manifest.json')
+				.then(function(response) {
+					return response.data;
+				})
+				.then(function(manifest) {
+					var filePromises = [];
+
+					angular.forEach(manifest.files, function(filename) {
+						// The manifests provide the production index file but Plunkr wants
+						// a straight index.html
+						if (filename === 'index-production.html') {
+							filename = 'index.html';
+						}
+
+						console.info('getting data for ', filename);
+						filePromises.push($http.get(exampleFolder + '/' + filename, { transformResponse: [] })
+							.then(function(response) {
+								console.info('got data for ', filename);
+
+								return {
+									name: filename,
+									content: response.data.replace(/(src\s*=\s*['"])([\.\/])/ig,
+										'$1' + location.protocol + '//' + location.host + '/' + exampleFolder + '/$2')
+								};
+							}));
+					});
+
+					return $q.all({
+						manifest: manifest,
+						files: $q.all(filePromises)
+					});
+				});
+		};
+	}]);

--- a/src/packages/website/templates/website/scripts/examples.js
+++ b/src/packages/website/templates/website/scripts/examples.js
@@ -215,8 +215,9 @@ angular.module('examples', [])
 								return {
 									name: filename,
 									// get content and replace relative links with full path
-									content: response.data.replace(/(src\s*=\s*['"])([\.\/])/ig,
-										'$1' + location.protocol + '//' + location.host + '/' + exampleFolder + '/$2')
+									content: response.data
+										.replace(/((?:src|href)\s*=\s*['"])(\/[a-z0-9])/ig, '$1' + location.protocol + '//' + location.host + '/$2')
+										.replace(/((?:src|href)\s*=\s*['"])([\.\/])/ig, '$1' + location.protocol + '//' + location.host + '/' + exampleFolder + '/$2')
 								};
 							}));
 					});

--- a/src/packages/website/templates/website/scripts/index.js
+++ b/src/packages/website/templates/website/scripts/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var DOCS_OVERWRITELINK = true;
 
-angular.module('docApp', ['ngMaterial'])
+angular.module('docApp', ['ngMaterial', 'examples'])
 .constant('DOCS_OVERWRITELINK', typeof DOCS_OVERWRITELINK === 'undefined' ? false : DOCS_OVERWRITELINK)
 .constant('SEARCH', [])
 .provider('DOCS_OVERWRITELINK', function (DOCS_OVERWRITELINK) {

--- a/src/packages/website/templates/website/styles/runnableExample.css
+++ b/src/packages/website/templates/website/styles/runnableExample.css
@@ -8,3 +8,7 @@
   border-width: 0px 1px 1px 1px;
   border-color: #ddd;
 }
+
+.runnable-example-frame {
+  width: 100%;
+}

--- a/src/templates/api/directive.template.html
+++ b/src/templates/api/directive.template.html
@@ -2,75 +2,76 @@
 {% extends "api/api.template.html" %}
 
 {% block additional %}
-  <h2>Directive Info</h2>
-  <ul>
-    {% if doc.scope %}<li>This directive creates new scope.</li>{% endif %}
-    <li>This directive executes at priority level {$ doc.priority $}.</li>
-    {% if doc.multiElement %}<li>This directive can be used as {@link $compile#-multielement- multiElement}</li>{% endif %}
-  </ul>
+<h2>Directive Info</h2>
+<ul>
+	{% if doc.scope %}<li>This directive creates new scope.</li>{% endif %}
+	<li>This directive executes at priority level {$ doc.priority $}.</li>
+	{% if doc.multiElement %}<li>This directive can be used as {@link $compile#-multielement- multiElement}</li>{% endif %}
+</ul>
 
-  {% block usage %}
-  <h2 id="usage">Usage</h2>
-  <div class="usage">
-  {% if doc.usage %}
-    {$ doc.usage | marked $}
-  {% else %}
-    <ul>
-    {% if doc.restrict.element %}
-      <li>as element:
-      {% if doc.name.indexOf('ng') == 0 -%}
-      (This directive can be used as custom element, but be aware of <a href="guide/ie">IE restrictions</a>).
-      {%- endif %}
-      {% code %}
-      <{$ doc.name | dashCase $}
-        {%- for param in doc.params -%}
-         {# skip attribute with name equal to directive name #}
-         {%- if (doc.name != param.alias and doc.name != param.name) %}
-          {$ lib.directiveParam(param, '="', '"') $}
-         {%- endif -%}
-        {%- endfor %}>
-        ...
-      </{$ doc.name | dashCase $}>
-      {% endcode %}
-      </li>
-    {% endif -%}
+{% block usage %}
+<h2 id="usage">Usage</h2>
+<div class="usage">
+	{% if doc.usage %}
+	{$ doc.usage | marked $}
+	{% else %}
+	<ul>
+		{% if doc.restrict.element %}
+		<li>as element:
+			{% if doc.name.indexOf('ng') == 0 -%}
+			(This directive can be used as custom element, but be aware of <a href="guide/ie">IE restrictions</a>).
+			{%- endif %}
+			{% code %}
+			<{$ doc.name | dashCase $}
+			{%- for param in doc.params -%}
+			{# skip attribute with name equal to directive name #}
+			{%- if (doc.name != param.alias and doc.name != param.name) %}
+			{$ lib.directiveParam(param, '="', '"') $}
+			{%- endif -%}
+			{%- endfor %}>
+			...
+		</{$ doc.name | dashCase $}>
+		{% endcode %}
+		</li>
+		{% endif -%}
 
-    {%- if doc.restrict.attribute -%}
-      <li>as attribute:
-        {% code %}
-        <{$ doc.element $}
-          {%- for param in doc.params %}
-          {$ lib.directiveParam(param, '="', '"', false, doc.name) $}
-          {%- endfor %}>
-        ...
-        </{$ doc.element $}>
-        {% endcode %}
-      </li>
-    {% endif -%}
+		{%- if doc.restrict.attribute -%}
+		<li>as attribute:
+			{% code %}
+			<{$ doc.element $}
+			{%- for param in doc.params %}
+			{$ lib.directiveParam(param, '="', '"', false, doc.name) $}
+			{%- endfor %}>
+			...
+		</{$ doc.element $}>
+		{% endcode %}
+		</li>
+		{% endif -%}
 
-    {%- if doc.restrict.cssClass -%}
-      <li>as CSS class:
-        {% code %}
-        {% set sep = joiner(' ') %}
-        <{$ doc.element $} class="
-        {%- for param in doc.params -%}
-          {$ sep() $}{$ lib.directiveParam(param, ': ', ';', true) $}
-        {%- endfor %}"> ... </{$ doc.element $}>
-        {% endcode %}
-      </li>
-    {% endif -%}
+		{%- if doc.restrict.cssClass -%}
+		<li>as CSS class:
+			{% code %}
+			{% set sep = joiner(' ') %}
+			<{$ doc.element $} class="
+			{%- for param in doc.params -%}
+			{$ sep() $}{$ lib.directiveParam(param, ': ', ';', true) $}
+			{%- endfor %}"> ... </{$ doc.element $}>
+		{% endcode %}
+		</li>
+		{% endif -%}
 
-  {%- endif %}
-  </div>
-  {% endblock -%}
+		{%- endif %}
+</div>
+{% endblock -%}
 
-  {%- if doc.animations %}
-  <h2 id="animations">Animations</h2>
-  {$ doc.animations | marked $}
-  {$ 'module:ngAnimate.$animate' | link('Click here', doc) $} to learn more about the steps involved in the animation.
-  {%- endif -%}
+{%- if doc.animations %}
+<h2 id="animations">Animations</h2>
+{$ doc.animations | marked $}
+{$ 'module:ngAnimate.$animate' | link('Click here', doc) $} to learn more about the steps involved in the animation.
+{%- endif -%}
 
-  {% include "lib/params.template.html" %}
-  {% include "lib/events.template.html" %}
-  {% include "lib/throws.template.html" %}
+{% include "lib/params.template.html" %}
+{% include "lib/methods.template.html" %}
+{% include "lib/events.template.html" %}
+{% include "lib/throws.template.html" %}
 {% endblock %}

--- a/src/templates/api/directive.template.html
+++ b/src/templates/api/directive.template.html
@@ -38,13 +38,13 @@
 		{%- if doc.restrict.attribute -%}
 		<li>as attribute:
 			{% code %}
-			<{$ doc.element $}
-			{%- for param in doc.params %}
-			{$ lib.directiveParam(param, '="', '"', false, doc.name) $}
-			{%- endfor %}>
-			...
-		</{$ doc.element $}>
-		{% endcode %}
+			<{$ doc.element $} data-{$ doc.name | dashCase $}
+				{%- for param in doc.params %}
+				data-{$ lib.directiveParam(param, '="', '"', false, doc.name) $}
+				{%- endfor %}>
+				...
+			</{$ doc.element $}>
+			{% endcode %}
 		</li>
 		{% endif -%}
 
@@ -72,6 +72,7 @@
 
 {% include "lib/params.template.html" %}
 {% include "lib/methods.template.html" %}
+{% include "lib/properties.template.html" %}
 {% include "lib/events.template.html" %}
 {% include "lib/throws.template.html" %}
 {% endblock %}

--- a/tasks/dgeni-alive.js
+++ b/tasks/dgeni-alive.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
         });
         
         if (packages.includes('dgeni-packages/examples')) {
-            docgenConfig.config(function(generateExamplesProcessor, generateProtractorTestsProcessor) {
+            docgenPackages.config(function(generateExamplesProcessor, generateProtractorTestsProcessor) {
                 generateExamplesProcessor.deployments = deployments;
                 generateProtractorTestsProcessor.deployments = deployments;
             })

--- a/tasks/dgeni-alive.js
+++ b/tasks/dgeni-alive.js
@@ -25,6 +25,13 @@ var defaults = {
     openBrowser : false
 };
 
+var deploymentDefaults = {
+    deployments : [{
+        name: 'default'
+    }],
+    deploymentTarget : 'default'
+};
+
 module.exports = function (grunt) {
     // register task
     grunt.registerMultiTask('dgeni-alive', 'Generate live docs with ngdoc/dgeni.', function () {
@@ -35,6 +42,9 @@ module.exports = function (grunt) {
         var dest = path.resolve(this.data.dest);
 
         var apiOptions = this.data;
+        
+        var deployments = _.extend({}, deploymentDefaults.deployments, this.options().deployments);
+        var deploymentTarget = this.options().deploymentTarget || deploymentDefaults.deploymentTarget;
 
         docgen.Package(packages || void(packages))
         // enable debug
@@ -49,6 +59,15 @@ module.exports = function (grunt) {
                     templateFinder.templateFolders.unshift(path.resolve(templatePath));
                 });
             }
+        })
+        
+        .config(function(generateExamplesProcessor, generateProtractorTestsProcessor) {
+            generateExamplesProcessor.deployments = deployments;
+            generateProtractorTestsProcessor.deployments = deployments;
+        })
+        
+        .config(function (renderDocsProcessor) {
+            renderDocsProcessor.extraData.deploymentTarget = deploymentTarget;
         })
 
         var done = this.async();

--- a/tasks/dgeni-alive.js
+++ b/tasks/dgeni-alive.js
@@ -46,12 +46,11 @@ module.exports = function (grunt) {
         var deployments = _.extend({}, deploymentDefaults.deployments, this.options().deployments);
         var deploymentTarget = this.options().deploymentTarget || deploymentDefaults.deploymentTarget;
 
-        docgen.Package(packages || void(packages))
+        var docgenPackages = docgen.Package(packages || void(packages))
         // enable debug
         .config(function(log) {
             log.level = debug? 'debug': 'info';
         })
-
         .config(function(templateFinder) {
             if(apiOptions.templatePaths) {
                 apiOptions.templatePaths.forEach(function(templatePath) {
@@ -59,16 +58,17 @@ module.exports = function (grunt) {
                     templateFinder.templateFolders.unshift(path.resolve(templatePath));
                 });
             }
-        })
+        });
         
-        .config(function(generateExamplesProcessor, generateProtractorTestsProcessor) {
-            generateExamplesProcessor.deployments = deployments;
-            generateProtractorTestsProcessor.deployments = deployments;
-        })
-        
-        .config(function (renderDocsProcessor) {
-            renderDocsProcessor.extraData.deploymentTarget = deploymentTarget;
-        })
+        if (packages.includes('dgeni-packages/examples')) {
+            docgenConfig.config(function(generateExamplesProcessor, generateProtractorTestsProcessor) {
+                generateExamplesProcessor.deployments = deployments;
+                generateProtractorTestsProcessor.deployments = deployments;
+            })
+            .config(function (renderDocsProcessor) {
+                renderDocsProcessor.extraData.deploymentTarget = deploymentTarget;
+            });
+        }
 
         var done = this.async();
         if (this.data.title) {


### PR DESCRIPTION
* Fixed live examples launching.
* Fixed dgeni-alive running at all without jsx.
* Fixed docs area was using guide in a few places
* Ported Plunker launcher from AngularJS project dgeni to dgeni-alive.
* Updated README with setup instructions for live examples.
* Added iframe-resizer (https://github.com/davidjbradshaw/iframe-resizer) to automatically resize live example content frames